### PR TITLE
Removing unused tables files in shared memory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ dbus utility, e.g.:
     gdbus call -e -d net.zoidplex.wlr_gamma_service -o /net/zoidplex/wlr_gamma_service -m net.zoidplex.wlr_gamma_service.brightness.increase 0.1
     gdbus call -e -d net.zoidplex.wlr_gamma_service -o /net/zoidplex/wlr_gamma_service -m net.zoidplex.wlr_gamma_service.brightness.decrease 0.1
     gdbus call -e -d net.zoidplex.wlr_gamma_service -o /net/zoidplex/wlr_gamma_service -m net.zoidplex.wlr_gamma_service.temperature.get
-    gdbus call -e -d net.zoidplex.wlr_gamma_service -o /net/zoidplex/wlr_gamma_service -m net.zoidplex.wlr_gamma_service.set_temperature.set 4000
+    gdbus call -e -d net.zoidplex.wlr_gamma_service -o /net/zoidplex/wlr_gamma_service -m net.zoidplex.wlr_gamma_service.temperature.set 4000
     gdbus call -e -d net.zoidplex.wlr_gamma_service -o /net/zoidplex/wlr_gamma_service -m net.zoidplex.wlr_gamma_service.temperature.increase 100
     gdbus call -e -d net.zoidplex.wlr_gamma_service -o /net/zoidplex/wlr_gamma_service -m net.zoidplex.wlr_gamma_service.temperature.decrease 100

--- a/src/wlrgammasvc.c
+++ b/src/wlrgammasvc.c
@@ -192,6 +192,15 @@ set_gamma(double new_brightness, int new_temp)
 	wl_display_flush(display);
 	current_brightness = new_brightness;
 	current_temp = new_temp;
+
+	// Closing unnecessary shared memory files
+	wl_list_for_each(output, &outputs, link) {
+		if (output->table_fd >= 0) {
+			munmap(output->table, output->ramp_size * 3 * sizeof(uint16_t));
+			close(output->table_fd);
+			fprintf(stdout, "\ttable closed\n");
+		}
+	}
 }
 
 static gboolean


### PR DESCRIPTION
Using repeatedly the `temperature.set` command may cause an error due to the maximum number of files that can be opened per-process. I added some lines to avoid that.
There is also a fix int the README.md: 

```
gdbus call -e -d net.zoidplex.wlr_gamma_service -o /net/zoidplex/wlr_gamma_service -m net.zoidplex.wlr_gamma_service.temperature.set 4000
``` 
instead of

```
gdbus call -e -d net.zoidplex.wlr_gamma_service -o /net/zoidplex/wlr_gamma_service -m net.zoidplex.wlr_gamma_service.set_temperature.set 4000
```